### PR TITLE
Merge from master (#82)

### DIFF
--- a/src/fr/cirad/mgdb/importing/DartImport.java
+++ b/src/fr/cirad/mgdb/importing/DartImport.java
@@ -424,21 +424,35 @@ public class DartImport extends AbstractGenotypeImport {
                                             if (!fDbAlreadyContainedIndividuals && finalMongoTemplate.findById(sIndividual, Individual.class) == null)  // we don't have any population data so we don't need to update the Individual if it already exists
                                                 indsToAdd.add(new Individual(sIndividual));
 
-                                            if (!indsToAdd.isEmpty() && indsToAdd.size() % 1000 == 0) {
-                                                finalMongoTemplate.insert(indsToAdd, Individual.class);
-                                                indsToAdd = new HashSet<>();
-                                            }
-
                                             int sampleId = AutoIncrementCounter.getNextSequence(finalMongoTemplate, MongoTemplateManager.getMongoCollectionName(GenotypingSample.class));
                                             m_providedIdToSampleMap.put(sIndOrSpId, new GenotypingSample(sampleId, finalProject.getId(), sRun, sIndividual, sampleToIndividualMap == null ? null : sIndOrSpId));   // add a sample for this individual to the project
                                         }
-
-                                        finalMongoTemplate.insert(m_providedIdToSampleMap.values(), GenotypingSample.class);
-                                        if (!indsToAdd.isEmpty()) {
-                                            finalMongoTemplate.insert(indsToAdd, Individual.class);
-                                            indsToAdd = null;
+                                        
+                                        // make sure provided sample names do not conflict with existing ones
+                                        if (finalMongoTemplate.findOne(new Query(Criteria.where(GenotypingSample.FIELDNAME_NAME).in(m_providedIdToSampleMap.values().stream().map(sp -> sp.getSampleName()).toList())), GenotypingSample.class) != null) {
+                                            progress.setError("Some of the sample IDs provided in the mapping file already exist in this database!");
+                                            return;
                                         }
+
+                                        final int importChunkSize = 1000;
+                                        Thread sampleImportThread = new Thread() {
+                                            public void run() {                 
+                                                List<GenotypingSample> samplesToImport = new ArrayList<>(m_providedIdToSampleMap.values());
+                                                for (int j=0; j<Math.ceil((float) m_providedIdToSampleMap.size() / importChunkSize); j++)
+                                                    finalMongoTemplate.insert(samplesToImport.subList(j * importChunkSize, Math.min(samplesToImport.size(), (j + 1) * importChunkSize)), GenotypingSample.class);
+                                                samplesToImport = null;
+                                            }
+                                        };
+                                        sampleImportThread.start();
+
+                                        List<Individual> individualsToImport = new ArrayList<>(indsToAdd);
+                                        for (int j=0; j<Math.ceil((float) individualsToImport.size() / importChunkSize); j++)
+                                        	finalMongoTemplate.insert(individualsToImport.subList(j * importChunkSize, Math.min(individualsToImport.size(), (j + 1) * importChunkSize)), Individual.class);
+                                        individualsToImport = null;
+
+                                        sampleImportThread.join();
                                         setSamplesPersisted(true);
+
                                         nNumberOfVariantsToSaveAtOnce.set(sampleIds.size() == 0 ? nMaxChunkSize : Math.max(1, nMaxChunkSize / sampleIds.size()));
                                         LOG.info("Importing by chunks of size " + nNumberOfVariantsToSaveAtOnce.get());
                                     }

--- a/src/fr/cirad/mgdb/importing/VcfImport.java
+++ b/src/fr/cirad/mgdb/importing/VcfImport.java
@@ -328,27 +328,35 @@ public class VcfImport extends AbstractGenotypeImport {
                 if (!fDbAlreadyContainedIndividuals || mongoTemplate.findById(sIndividual, Individual.class) == null)  // we don't have any population data so we don't need to update the Individual if it already exists
                     indsToAdd.add(new Individual(sIndividual));
 
-                if (!indsToAdd.isEmpty() && indsToAdd.size() % 1000 == 0) {
-                    mongoTemplate.insert(indsToAdd, Individual.class);
-                    indsToAdd = new HashSet<>();
-                }
-
                 int sampleId = AutoIncrementCounter.getNextSequence(mongoTemplate, MongoTemplateManager.getMongoCollectionName(GenotypingSample.class));
                 m_providedIdToSampleMap.put(sIndOrSpId, new GenotypingSample(sampleId, project.getId(), sRun, sIndividual, sampleToIndividualMap == null ? null : sIndOrSpId));   // add a sample for this individual to the project
             }
             
             // make sure provided sample names do not conflict with existing ones
             if (finalMongoTemplate.findOne(new Query(Criteria.where(GenotypingSample.FIELDNAME_NAME).in(m_providedIdToSampleMap.values().stream().map(sp -> sp.getSampleName()).toList())), GenotypingSample.class) != null) {
-    	        progress.setError("Some of the sample IDs provided in the mapping file already exist in this database!");
-    	        return null;
-    		}
-
-            mongoTemplate.insert(m_providedIdToSampleMap.values(), GenotypingSample.class);
-            if (!indsToAdd.isEmpty()) {
-                mongoTemplate.insert(indsToAdd, Individual.class);
-                indsToAdd = null;
+                progress.setError("Some of the sample IDs provided in the mapping file already exist in this database!");
+                return null;
             }
+
+            final int importChunkSize = 1000;
+            Thread sampleImportThread = new Thread() {
+                public void run() {                 
+                    List<GenotypingSample> samplesToImport = new ArrayList<>(m_providedIdToSampleMap.values());
+                    for (int j=0; j<Math.ceil((float) m_providedIdToSampleMap.size() / importChunkSize); j++)
+                        finalMongoTemplate.insert(samplesToImport.subList(j * importChunkSize, Math.min(samplesToImport.size(), (j + 1) * importChunkSize)), GenotypingSample.class);
+                    samplesToImport = null;
+                }
+            };
+            sampleImportThread.start();
+
+            List<Individual> individualsToImport = new ArrayList<>(indsToAdd);
+            for (int j=0; j<Math.ceil((float) individualsToImport.size() / importChunkSize); j++)
+                mongoTemplate.insert(individualsToImport.subList(j * importChunkSize, Math.min(individualsToImport.size(), (j + 1) * importChunkSize)), Individual.class);
+            individualsToImport = null;
+
+            sampleImportThread.join();
             setSamplesPersisted(true);
+
 
             // loop over each variation
             final Integer nAssemblyId = assembly == null ? null : assembly.getId();

--- a/src/fr/cirad/mgdb/importing/base/RefactoredImport.java
+++ b/src/fr/cirad/mgdb/importing/base/RefactoredImport.java
@@ -522,26 +522,34 @@ public abstract class RefactoredImport extends AbstractGenotypeImport {
             if (!fDbAlreadyContainedIndividuals || mongoTemplate.findById(sIndividual, Individual.class) == null)  // we don't have any population data so we don't need to update the Individual if it already exists
                 indsToAdd.add(new Individual(sIndividual));
 
-            if (!indsToAdd.isEmpty() && indsToAdd.size() % 1000 == 0) {
-            	mongoTemplate.insert(indsToAdd, Individual.class);
-                indsToAdd = new HashSet<>();
-            }
-
             int sampleId = AutoIncrementCounter.getNextSequence(mongoTemplate, MongoTemplateManager.getMongoCollectionName(GenotypingSample.class));
             m_providedIdToSampleMap.put(sIndOrSpId, new GenotypingSample(sampleId, projId, sRun, sIndividual, sampleToIndividualMap == null ? null : sIndOrSpId));   // add a sample for this individual to the project
         }
         
         // make sure provided sample names do not conflict with existing ones
         if (mongoTemplate.findOne(new Query(Criteria.where(GenotypingSample.FIELDNAME_NAME).in(m_providedIdToSampleMap.values().stream().map(sp -> sp.getSampleName()).toList())), GenotypingSample.class) != null) {
-	        progress.setError("Some of the sample IDs provided in the mapping file already exist in this database!");
-	        return;
-		}
+            progress.setError("Some of the sample IDs provided in the mapping file already exist in this database!");
+            return;
+        }
 
-        mongoTemplate.insert(m_providedIdToSampleMap.values(), GenotypingSample.class);
-        if (!indsToAdd.isEmpty()) {
-        	mongoTemplate.insert(indsToAdd, Individual.class);
-            indsToAdd = null;
-        }	                    					
+        final int importChunkSize = 1000;
+        Thread sampleImportThread = new Thread() {
+            public void run() {                 
+                List<GenotypingSample> samplesToImport = new ArrayList<>(m_providedIdToSampleMap.values());
+                for (int j=0; j<Math.ceil((float) m_providedIdToSampleMap.size() / importChunkSize); j++)
+                	mongoTemplate.insert(samplesToImport.subList(j * importChunkSize, Math.min(samplesToImport.size(), (j + 1) * importChunkSize)), GenotypingSample.class);
+                samplesToImport = null;
+            }
+        };
+        sampleImportThread.start();
+
+        List<Individual> individualsToImport = new ArrayList<>(indsToAdd);
+        for (int j=0; j<Math.ceil((float) individualsToImport.size() / importChunkSize); j++)
+            mongoTemplate.insert(individualsToImport.subList(j * importChunkSize, Math.min(individualsToImport.size(), (j + 1) * importChunkSize)), Individual.class);
+        individualsToImport = null;
+
+        sampleImportThread.join();
         setSamplesPersisted(true);
+
     }
 }


### PR DESCRIPTION
* Merged from staging for next release (#80)

* Added means to import INDELs from PLINK data, alleles encoded as I and D

... the workaround to make it htsjdk compatible is turning I into NN and D in to N

* Generalizing support for I and D alleles

* add function to check if the user can edit calls

* Exporting alleles of INDELs with unknown sequence as I/D

for all individual-oriented formats

* Export optim (#78)

* Implemented async exports from temp collections

* POM dependency upgrade

* Parallelized export functional for variant-oriented formats

* Added means to write variant-list files as chunks when exporting

* Minor changes

* Individual-oriented exports now working in parallel

* Minor change

* Added mean to specify a location for export extraction files

* Added mean to specify a location for export extraction files

+ fixed outputstream flush / close

* All seems to be working fine

* Minor changes

* insertStep method in ProgressIndicator adds step at next position

* Added safelyGetKnownAlleles() method

which allows to fix incomplete known allele lists in VRD records

* Replacing dots with underscores in metadata field names

This used to cause trouble in the JSON document structure

* Made taxon update immediately accounted for

* add listReadableDbs in AbstractTokenManager

* POM version update

* Filter export data on project IDs if several projects in DB

(faster export!)

* Added some debug facility to GroupedExecutor

* Improved debug info for GroupedExecutor

* Minor change

* Fixed chunk count problem with IGV exports

* Minor changes

* Minor changes

* Moved VisualizationService class from Gigwa2ServiceImpl to Mgdb2Export

* Made readToken method static

---------



* Provided means to generate prefixed variant IDs at initial import time

* Reusing known INDEL alleles instead of adding N/NN

... for cases where we work on a predefined biallelic variant list

* Added support for Affymetrix variant IDs

* getSamplesByIndividualForProject now accounts for empty individual list

* Renamed Affymetrix synonym type to Axiom

* Added support for databaseNamePrefix config property

* Made identification of variants by position optional

* Remove project refs from variants collection when deleting projects

* Fixed sporadic bug in importing individuals when sample names provided

---------